### PR TITLE
change type of field messageErrorCode from java.lang.String to int

### DIFF
--- a/src/main/java/com/cm/text/models/Response.java
+++ b/src/main/java/com/cm/text/models/Response.java
@@ -47,7 +47,7 @@ public class Response {
         private String messageDetails ;
 
         @SerializedName("messageErrorCode")
-        private String messageErrorCode;
+        private int messageErrorCode;
 
         @SerializedName("parts")
         private int parts;
@@ -69,11 +69,11 @@ public class Response {
             this.messageDetails = messageDetails;
         }
 
-        public String getMessageErrorCode() {
+        public int getMessageErrorCode() {
             return messageErrorCode;
         }
 
-        public void setMessageErrorCode(String messageErrorCode) {
+        public void setMessageErrorCode(int messageErrorCode) {
             this.messageErrorCode = messageErrorCode;
         }
 


### PR DESCRIPTION
A small change which resolves #27 and fixes the datatype of the `Response` member `messageErrorCode`. 